### PR TITLE
ci: add github-workflow based CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,37 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        default: true
+        override: true
+        components: clippy, rustfmt
+
+    - name: Cancel previous runs
+      uses: styfle/cancel-workflow-action@0.5.0
+      with:
+        access_token: ${{ github.token }}
+
+    - name: Check formatting
+      run: cargo fmt  -- --check
+
+    - name: Run linter
+      uses: actions-rs/clippy-check@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        args: --tests -- -Wclippy::all -Wclippy::imprecise_flops
+
+    - name: Run tests
+      run: cargo test


### PR DESCRIPTION
This PR addes a github CI workflow. It _should fail_ because the repo currently is not formatted and has a few [clippy lints].

[clippy lints]: https://github.com/JayKickliter/RusticSOM/runs/1456372067?check_suite_focus=true